### PR TITLE
fix: null entitiy "crash" in getOtherEntities

### DIFF
--- a/src/main/java/nofrills/misc/Utils.java
+++ b/src/main/java/nofrills/misc/Utils.java
@@ -265,7 +265,7 @@ public class Utils {
     public static List<Entity> getOtherEntities(Entity except, Box box, Predicate<? super Entity> filter) {
         List<Entity> entities = new ArrayList<>();
         for (Entity ent : getEntities()) {
-            if (ent != except && (filter == null || filter.test(ent)) && ent.getBoundingBox().intersects(box)) {
+            if (ent != null && ent != except && (filter == null || filter.test(ent)) && ent.getBoundingBox().intersects(box)) {
                 entities.add(ent);
             }
         }


### PR DESCRIPTION
Might just be a mod conflict but the entity can be null

<details>
<summary>Disconnect Log</summary>

---- Minecraft Network Protocol Error Report ----
// This time is not my fault, I promise!
// Server bug reporting link: https://hypixel.net/bug-reports/create

Time: 2025-07-15 16:48:17
Description: Packet handling error

java.lang.NullPointerException: Cannot invoke "net.minecraft.class_1297.method_5829()" because "ent" is null
	at knot//nofrills.misc.Utils.getOtherEntities(Utils.java:268)
	at knot//nofrills.features.ForagingFeatures.hasInvisibugMarker(ForagingFeatures.java:66)
	at knot//nofrills.features.ForagingFeatures.onParticle(ForagingFeatures.java:86)
	at knot//meteordevelopment.orbit.listeners.LambdaListener.call(LambdaListener.java:83)
	at knot//meteordevelopment.orbit.EventBus.post(EventBus.java:67)
	at knot//net.minecraft.class_634.handler$ckg001$nofrills$onParticle(class_634.java:10219)
	at knot//net.minecraft.class_634.method_11077(class_634.java)
	at knot//net.minecraft.class_2675.method_11553(class_2675.java:75)
	at knot//net.minecraft.class_2675.method_65081(class_2675.java:11)
	at knot//net.minecraft.class_2535.method_10759$mixinextras$wrapped$94(class_2535.java:208)
	at knot//net.minecraft.class_2535.mixinextras$bridge$method_10759$mixinextras$wrapped$94$95(class_2535.java)
	at knot//net.minecraft.class_2535.wrapMethod$coa000$skyblock-api$genericsFtw(class_2535.java:3255)
	at knot//net.minecraft.class_2535.method_10759(class_2535.java)
	at knot//net.minecraft.class_2535.method_10770(class_2535.java:193)
	at knot//net.minecraft.class_2535.channelRead0(class_2535.java:69)
	at knot//io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.flow.FlowControlHandler.dequeue(FlowControlHandler.java:202)
	at knot//io.netty.handler.flow.FlowControlHandler.channelRead(FlowControlHandler.java:164)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:333)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:455)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:289)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1357)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:868)
	at knot//io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at knot//io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:796)
	at knot//io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:732)
	at knot//io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:658)
	at knot//io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
	at knot//io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
	at knot//io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1583)


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Thread: Netty Client IO #1
Stacktrace:
	at knot//nofrills.misc.Utils.getOtherEntities(Utils.java:268)
	at knot//nofrills.features.ForagingFeatures.hasInvisibugMarker(ForagingFeatures.java:66)
	at knot//nofrills.features.ForagingFeatures.onParticle(ForagingFeatures.java:86)
	at knot//meteordevelopment.orbit.listeners.LambdaListener.call(LambdaListener.java:83)
	at knot//meteordevelopment.orbit.EventBus.post(EventBus.java:67)
	at knot//net.minecraft.class_634.handler$ckg001$nofrills$onParticle(class_634.java:10219)
	at knot//net.minecraft.class_634.method_11077(class_634.java)
	at knot//net.minecraft.class_2675.method_11553(class_2675.java:75)
	at knot//net.minecraft.class_2675.method_65081(class_2675.java:11)
	at knot//net.minecraft.class_2535.method_10759$mixinextras$wrapped$94(class_2535.java:208)
Mixins in Stacktrace:
	net.minecraft.class_634:
		me.nobaboy.nobaaddons.mixins.events.SoundEventsMixin (nobaaddons.mixins.json)
		dev.architectury.mixin.fabric.client.MixinClientPacketListener (architectury.mixins.json)
		net.fabricmc.fabric.mixin.attachment.client.ClientPlayNetworkHandlerMixin (fabric-data-attachment-api-v1.client.mixins.json)
		tech.thatgravyboat.skyblockapi.mixins.fixes.ClientPacketListenerMixin (skyblock-api.client.mixins.json)
		moe.nea.firmament.mixins.SlotUpdateListener (firmament.mixins.json)
		codes.cookies.mod.utils.mixins.spam.ClientPlayNetworkHandlerMixin (cookies-mod.utils.mixins.json)
		net.fabricmc.fabric.mixin.command.client.ClientPlayNetworkHandlerMixin (fabric-command-api-v2.client.mixins.json)
		net.fabricmc.fabric.mixin.networking.client.ClientPlayNetworkHandlerMixin (fabric-networking-api-v1.client.mixins.json)
		dev.mayaqq.titanomachy.mixin.ClientPacketListenerMixin (titanomachy.mixins.json)
		nofrills.mixin.ClientPlayNetworkHandlerMixin (nofrills.mixins.json)
		net.fabricmc.fabric.mixin.client.message.ClientPlayNetworkHandlerMixin (fabric-message-api-v1.client.mixins.json)
		net.fabricmc.fabric.mixin.event.lifecycle.client.ClientPlayNetworkHandlerMixin (fabric-lifecycle-events-v1.client.mixins.json)
		moe.nea.firmament.mixins.EntityUpdateEventListener (firmament.mixins.json)
		mod.crend.libbamboo.mixin.ClientPlayNetworkHandlerMixin (libbamboo.mixins.json)
		at.hannibal2.skyhanni.mixins.transformers.MixinClientPlayNetworkHandler (mixins.skyhanni.json)
		me.nobaboy.nobaaddons.mixins.events.ParticleEventsMixin (nobaaddons.mixins.json)
		net.caffeinemc.mods.sodium.mixin.core.world.map.ClientPacketListenerMixin (sodium-common.mixins.json)
		moe.nea.firmament.mixins.IncomingPacketListenerPatches (firmament.mixins.json)
		dzwdz.chat_heads.mixin.ClientPacketListenerMixin (chat_heads.mixins.json)
		codes.cookies.mod.events.mixins.PlayerListMixin (cookies-mod.events.mixins.json)
		moe.nea.firmament.mixins.SoundReceiveEventPatch (firmament.mixins.json)
		mod.crend.autohud.mixin.ClientPlayNetworkHandlerMixin (autohud.mixins.json)
		org.pkozak.mixin.client.ClientNetworkHandlerMixin (mc-movie-edition.client.mixins.json)
		de.keksuccino.konkrete.mixin.mixins.client.IMixinClientPacketListener (konkrete.mixins.json)
		codes.cookies.mod.utils.mixins.ClientPlayNetworkHandlerMixin (cookies-mod.utils.mixins.json)
		moe.nea.firmament.mixins.SaveOriginalCommandTreePacket (firmament.mixins.json)
		net.xolt.freecam.mixins.ClientPacketListenerMixin (freecam-common.mixins.json)
	net.minecraft.class_2535:
		tech.thatgravyboat.skyblockapi.mixins.events.ConnectionMixin (skyblock-api.client.mixins.json)
		net.fabricmc.fabric.mixin.attachment.ClientConnectionMixin (fabric-data-attachment-api-v1.mixins.json)
		me.nobaboy.nobaaddons.mixins.events.PacketEventsMixin (nobaaddons.mixins.json)
		nofrills.mixin.ClientConnectionMixin (nofrills.mixins.json)
		net.fabricmc.fabric.mixin.recipe.ingredient.ClientConnectionMixin (fabric-recipe-api-v1.mixins.json)
		dzwdz.chat_heads.mixin.ConnectionMixin (chat_heads.mixins.json)
		net.fabricmc.fabric.mixin.networking.ClientConnectionMixin (fabric-networking-api-v1.mixins.json)
		at.hannibal2.skyhanni.mixins.transformers.MixinClientConnection (mixins.skyhanni.json)

-- Connection --
Details:
	Protocol: play
	Flow: CLIENTBOUND
	Is Local: false
	Server type: OTHER
	Server brand: Hypixel BungeeCord (2025.7.7.1) <- Hygot 2025.7.14.1
Stacktrace:
	at knot//net.minecraft.class_2547.method_55622(class_2547.java:33)
	at knot//net.minecraft.class_2600.method_59803(class_2600.java:62)
	at knot//net.minecraft.class_8673.method_60882(class_8673.java:131)
	at knot//net.minecraft.class_8673.method_60881(class_8673.java:122)
	at knot//net.minecraft.class_2535.exceptionCaught(class_2535.java:161)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:346)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:447)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.flow.FlowControlHandler.dequeue(FlowControlHandler.java:202)
	at knot//io.netty.handler.flow.FlowControlHandler.channelRead(FlowControlHandler.java:164)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:333)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:455)
	at knot//io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:289)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at knot//io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1357)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
	at knot//io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at knot//io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:868)
	at knot//io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at knot//io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:796)
	at knot//io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:732)
	at knot//io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:658)
	at knot//io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
	at knot//io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
	at knot//io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Mixins in Stacktrace:
	net.minecraft.class_8673:
		moe.nea.firmament.mixins.OutgoingPacketEventPatch (firmament.mixins.json)
		net.fabricmc.fabric.mixin.networking.client.accessor.ClientCommonNetworkHandlerAccessor (fabric-networking-api-v1.client.mixins.json)
		tech.thatgravyboat.skyblockapi.mixins.events.ClientCommonPacketListenerImplMixin (skyblock-api.client.mixins.json)
		net.fabricmc.fabric.mixin.networking.client.ClientCommonNetworkHandlerMixin (fabric-networking-api-v1.client.mixins.json)
	net.minecraft.class_2535:
		tech.thatgravyboat.skyblockapi.mixins.events.ConnectionMixin (skyblock-api.client.mixins.json)
		net.fabricmc.fabric.mixin.attachment.ClientConnectionMixin (fabric-data-attachment-api-v1.mixins.json)
		me.nobaboy.nobaaddons.mixins.events.PacketEventsMixin (nobaaddons.mixins.json)
		nofrills.mixin.ClientConnectionMixin (nofrills.mixins.json)
		net.fabricmc.fabric.mixin.recipe.ingredient.ClientConnectionMixin (fabric-recipe-api-v1.mixins.json)
		dzwdz.chat_heads.mixin.ConnectionMixin (chat_heads.mixins.json)
		net.fabricmc.fabric.mixin.networking.ClientConnectionMixin (fabric-networking-api-v1.mixins.json)
		at.hannibal2.skyhanni.mixins.transformers.MixinClientConnection (mixins.skyhanni.json)

-- Custom Server Details --
Details:
	Proxy Instance: chi-hp-bungee56
	Server Name: mini150DW
	Proxy Version: 2025.7.7.1
	Player UUID: b75d7e0a-03d0-4c2a-ae47-809b6b808246
	Server Type: SKYBLOCK
	Join Time: Jul 15 2025 09:37:23 EDT

-- System Details --
Details:
	Minecraft Version: 1.21.5
	Minecraft Version ID: 1.21.5
	Operating System: Windows 11 (amd64) version 10.0
	Java Version: 21.0.3, Eclipse Adoptium
	Java VM Version: OpenJDK 64-Bit Server VM (mixed mode, sharing), Eclipse Adoptium
	Memory: 2418118112 bytes (2306 MiB) / 4202692608 bytes (4008 MiB) up to 4294967296 bytes (4096 MiB)
	CPUs: 16
	Processor Vendor: GenuineIntel
	Processor Name: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
	Identifier: Intel64 Family 6 Model 165 Stepping 5
	Microarchitecture: Comet Lake
	Frequency (GHz): 2.90
	Number of physical packages: 1
	Number of physical CPUs: 8
	Number of logical CPUs: 16
	Graphics card #0 name: NVIDIA GeForce RTX 3060 Ti
	Graphics card #0 vendor: NVIDIA
	Graphics card #0 VRAM (MiB): 8192.00
	Graphics card #0 deviceId: VideoController1
	Graphics card #0 versionInfo: 32.0.15.7652
	Memory slot #0 capacity (MiB): 8192.00
	Memory slot #0 clockSpeed (GHz): 2.13
	Memory slot #0 type: DDR4
	Memory slot #1 capacity (MiB): 8192.00
	Memory slot #1 clockSpeed (GHz): 2.13
	Memory slot #1 type: DDR4
	Virtual memory max (MiB): 29183.56
	Virtual memory used (MiB): 26035.16
	Swap memory total (MiB): 12909.41
	Swap memory used (MiB): 1449.86
	Space in storage for jna.tmpdir (MiB): <path not set>
	Space in storage for org.lwjgl.system.SharedLibraryExtractPath (MiB): <path not set>
	Space in storage for io.netty.native.workdir (MiB): <path not set>
	Space in storage for java.io.tmpdir (MiB): available: 45967.32, total: 952939.88
	Space in storage for workdir (MiB): available: 45967.32, total: 952939.88
	JVM Flags: 3 total; -XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump -Xms512m -Xmx4096m
	Fabric Mods: 
		architectury: Architectury 16.1.4
		autohud: Auto HUD 8.7
			libbamboo: LibBamboo 2.17
		capes: Capes 1.5.5+1.21.5
		chat_heads: Chat Heads 0.13.18
		chatanimation: ChatAnimation 1.0.6
		cloth-config: Cloth Config v17 18.0.145
			cloth-basic-math: cloth-basic-math 0.6.1
		compacting: Compacting 1.0.4
		continuebutton: Continue Button 1.1.0
		cookies-mod: cookies-mod 1.4.0
		customscoreboard: Custom Scoreboard 1.7.1
			meowdding-lib: Meowdding-Lib 1.0.53
				meowdding-patches: Meowdding-Patches 1.0.4
			olympus: Olympus 1.3.6
			resourcefulconfig: Resourcefulconfig 3.5.14
			resourcefulconfigkt: Resourceful Config Kotlin 3.5.12
		dynamic_fps: Dynamic FPS 3.9.5
			net_lostluma_battery: battery 1.3.0
		entityculling: EntityCulling 1.8.1
			transition: TRansition 1.0.3
			trender: TRender 1.0.5
		fabric-api: Fabric API 0.128.1+1.21.5
			fabric-api-base: Fabric API Base 0.4.62+73a52b4b49
			fabric-api-lookup-api-v1: Fabric API Lookup API (v1) 1.6.96+86c3a9f149
			fabric-biome-api-v1: Fabric Biome API (v1) 16.0.7+2dd063df49
			fabric-block-api-v1: Fabric Block API (v1) 1.1.0+ed91556f49
			fabric-block-view-api-v2: Fabric BlockView API (v2) 1.0.26+aa6d566c49
			fabric-blockrenderlayer-v1: Fabric BlockRenderLayer Registration (v1) 2.0.16+86c3a9f149
			fabric-client-tags-api-v1: Fabric Client Tags 1.1.37+86c3a9f149
			fabric-command-api-v1: Fabric Command API (v1) 1.2.70+f71b366f49
			fabric-command-api-v2: Fabric Command API (v2) 2.2.49+73a52b4b49
			fabric-commands-v0: Fabric Commands (v0) 0.2.87+df3654b349
			fabric-content-registries-v0: Fabric Content Registries (v0) 10.0.14+3e6c1f7d49
			fabric-convention-tags-v1: Fabric Convention Tags 2.1.33+7f945d5b49
			fabric-convention-tags-v2: Fabric Convention Tags (v2) 2.15.2+6d9989f349
			fabric-crash-report-info-v1: Fabric Crash Report Info (v1) 0.3.12+86c3a9f149
			fabric-data-attachment-api-v1: Fabric Data Attachment API (v1) 1.8.5+6d9989f349
			fabric-data-generation-api-v1: Fabric Data Generation API (v1) 22.5.2+a0fab30c49
			fabric-dimensions-v1: Fabric Dimensions API (v1) 4.0.17+3e6c1f7d49
			fabric-entity-events-v1: Fabric Entity Events (v1) 2.1.0+3ce7866349
			fabric-events-interaction-v0: Fabric Events Interaction (v0) 4.0.15+64e3057949
			fabric-game-rule-api-v1: Fabric Game Rule API (v1) 1.0.70+c327076a49
			fabric-item-api-v1: Fabric Item API (v1) 11.4.1+e46fd76a49
			fabric-item-group-api-v1: Fabric Item Group API (v1) 4.2.9+3459fc6149
			fabric-key-binding-api-v1: Fabric Key Binding API (v1) 1.0.63+ecf51cdc49
			fabric-keybindings-v0: Fabric Key Bindings (v0) 0.2.61+df3654b349
			fabric-lifecycle-events-v1: Fabric Lifecycle Events (v1) 2.6.0+230071a049
			fabric-loot-api-v2: Fabric Loot API (v2) 3.0.48+3f89f5a549
			fabric-loot-api-v3: Fabric Loot API (v3) 1.0.36+86c3a9f149
			fabric-message-api-v1: Fabric Message API (v1) 6.1.0+fe971bba49
			fabric-model-loading-api-v1: Fabric Model Loading API (v1) 5.2.3+5281b90749
			fabric-networking-api-v1: Fabric Networking API (v1) 4.5.0+775be32c49
			fabric-object-builder-api-v1: Fabric Object Builder API (v1) 21.1.2+b8d6ba7049
			fabric-particles-v1: Fabric Particles (v1) 4.1.2+112e550e49
			fabric-recipe-api-v1: Fabric Recipe API (v1) 8.1.8+3235ab3249
			fabric-registry-sync-v0: Fabric Registry Sync (v0) 6.1.22+cd64004349
			fabric-renderer-api-v1: Fabric Renderer API (v1) 6.1.2+bdf4842249
			fabric-renderer-indigo: Fabric Renderer - Indigo 3.1.2+5281b90749
			fabric-rendering-data-attachment-v1: Fabric Rendering Data Attachment (v1) 0.3.64+73761d2e49
			fabric-rendering-fluids-v1: Fabric Rendering Fluids (v1) 3.1.27+86c3a9f149
			fabric-rendering-v1: Fabric Rendering (v1) 11.3.0+a272b33849
			fabric-resource-conditions-api-v1: Fabric Resource Conditions API (v1) 5.0.21+73a52b4b49
			fabric-resource-loader-v0: Fabric Resource Loader (v0) 3.1.7+847e5f5c49
			fabric-screen-api-v1: Fabric Screen API (v1) 2.0.46+86c3a9f149
			fabric-screen-handler-api-v1: Fabric Screen Handler API (v1) 1.3.129+c327076a49
			fabric-sound-api-v1: Fabric Sound API (v1) 1.0.38+86c3a9f149
			fabric-tag-api-v1: Fabric Tag API (v1) 1.0.17+ecf51cdc49
			fabric-transfer-api-v1: Fabric Transfer API (v1) 5.4.24+7b20cbb049
			fabric-transitive-access-wideners-v1: Fabric Transitive Access Wideners (v1) 6.3.17+f17a180c49
		fabric-language-kotlin: Fabric Language Kotlin 1.13.4+kotlin.2.2.0
			org_jetbrains_kotlin_kotlin-reflect: kotlin-reflect 2.2.0
			org_jetbrains_kotlin_kotlin-stdlib: kotlin-stdlib 2.2.0
			org_jetbrains_kotlin_kotlin-stdlib-jdk7: kotlin-stdlib-jdk7 2.2.0
			org_jetbrains_kotlin_kotlin-stdlib-jdk8: kotlin-stdlib-jdk8 2.2.0
			org_jetbrains_kotlinx_atomicfu-jvm: atomicfu-jvm 0.28.0
			org_jetbrains_kotlinx_kotlinx-coroutines-core-jvm: kotlinx-coroutines-core-jvm 1.10.2
			org_jetbrains_kotlinx_kotlinx-coroutines-jdk8: kotlinx-coroutines-jdk8 1.10.2
			org_jetbrains_kotlinx_kotlinx-datetime-jvm: kotlinx-datetime-jvm 0.6.2
			org_jetbrains_kotlinx_kotlinx-io-bytestring-jvm: kotlinx-io-bytestring-jvm 0.7.0
			org_jetbrains_kotlinx_kotlinx-io-core-jvm: kotlinx-io-core-jvm 0.7.0
			org_jetbrains_kotlinx_kotlinx-serialization-cbor-jvm: kotlinx-serialization-cbor-jvm 1.8.1
			org_jetbrains_kotlinx_kotlinx-serialization-core-jvm: kotlinx-serialization-core-jvm 1.8.1
			org_jetbrains_kotlinx_kotlinx-serialization-json-jvm: kotlinx-serialization-json-jvm 1.8.1
		fabricloader: Fabric Loader 0.16.14
		ferritecore: FerriteCore 8.0.0
		firmament: Firmament 3.4.0+mc1.21.5
			io_ktor_ktor-client-content-negotiation-jvm: ktor-client-content-negotiation-jvm 3.1.2
			io_ktor_ktor-client-core-jvm: ktor-client-core-jvm 3.1.2
			io_ktor_ktor-client-encoding-jvm: ktor-client-encoding-jvm 3.1.2
			io_ktor_ktor-client-java-jvm: ktor-client-java-jvm 3.1.2
			io_ktor_ktor-client-logging-jvm: ktor-client-logging-jvm 3.1.2
			io_ktor_ktor-events-jvm: ktor-events-jvm 3.1.2
			io_ktor_ktor-http-cio-jvm: ktor-http-cio-jvm 3.1.2
			io_ktor_ktor-http-jvm: ktor-http-jvm 3.1.2
			io_ktor_ktor-io-jvm: ktor-io-jvm 3.1.2
			io_ktor_ktor-network-jvm: ktor-network-jvm 3.1.2
			io_ktor_ktor-serialization-jvm: ktor-serialization-jvm 3.1.2
			io_ktor_ktor-serialization-kotlinx-json-jvm: ktor-serialization-kotlinx-json-jvm 3.1.2
			io_ktor_ktor-serialization-kotlinx-jvm: ktor-serialization-kotlinx-jvm 3.1.2
			io_ktor_ktor-sse-jvm: ktor-sse-jvm 3.1.2
			io_ktor_ktor-utils-jvm: ktor-utils-jvm 3.1.2
			io_ktor_ktor-websocket-serialization-jvm: ktor-websocket-serialization-jvm 3.1.2
			io_ktor_ktor-websockets-jvm: ktor-websockets-jvm 3.1.2
			jarviscci: Jarvis Common Config Index 1.1.4
			mm_shedaniel: Manningham Mills (shedaniel's fork) 2.4.1
			org_slf4j_slf4j-api: slf4j-api 2.0.16
		firstperson: FirstPerson 2.5.0
		forgeconfigapiport: Forge Config API Port 21.5.1
			com_electronwill_night-config_core: core 3.8.1
			com_electronwill_night-config_toml: toml 3.8.1
		freecam: Freecam 1.3.3+mc1.21.5
		fzzy_config: Fzzy Config 0.7.0+1.21.5
			blue_endless_jankson: jankson 1.2.3
			fabric-permissions-api-v0: fabric-permissions-api 0.3.3
			net_peanuuutz_tomlkt_tomlkt-jvm: tomlkt-jvm 0.3.7
		hypixel-mod-api: Hypixel Mod API 1.0.1+build.1+mc1.21
			net_hypixel_mod-api: mod-api 1.0.1
		java: OpenJDK 64-Bit Server VM 21
		konkrete: Konkrete 1.9.11
		lithium: Lithium 0.16.3+mc1.21.5
		mc-movie-edition: Minecraft - Movie edition 1.0.1-1.21.5
		minecraft: Minecraft 1.21.5
		mixintrace: MixinTrace 1.1.1+1.17
		modelfix: Model Gap Fix 1.21.5-1.12
		modmenu: Mod Menu 14.0.0-rc.2
		morechathistory: More Chat History 1.3.1
		mru: M.R.U 1.0.17+1.21.5+fabric
			org_commonmark_commonmark: commonmark 0.21.0
		nobaaddons: NobaAddons 1.0.0-Beta.5
			commander: commander 2.1.1
			dev_celestialfault_histoire: histoire 1.2.0
		nofrills: NoFrills 0.3.10
			meteordevelopment_orbit: orbit 0.2.4
		notenoughanimations: NotEnoughAnimations 1.10.1
		orbit: Orbit 1.0.0
		particlerain: Particle Rain 4.0.0-alpha-2+1.21.5-fabric
		placeholder-api: Placeholder API 2.6.4+1.21.5
		reactivemusic: Reactive Music 1.0.3+1.21.4
		resourcefullib: Resourceful Lib 3.5.0
			com_teamresourceful_bytecodecs: bytecodecs 1.1.3
			com_teamresourceful_yabn: yabn 1.0.3
		scoreboard-overhaul: Scoreboard Overhaul 1.4.0+mc1.21.5
		screencopy: Screencopy 1.2.6
			com_github_ramanrajarathinam_native-utils: native-utils 1.0.0
			io_github_imurx_arboard: arboard 1.1.3
		skinlayers3d: 3d-Skin-Layers 1.8.1
		skyblock: Sky-Block 1.0.2
		skyblockpv: SkyBlock PV 1.4.0
			com_notkamui_libs_keval-jvm: keval-jvm 1.1.1
		skyblockrpc: SkyBlockRPC 1.0.0
			com_jagrosh_discordipc: DiscordIPC 0.5.3
		skyblocktweaks-fabric: Skyblock Tweaks 0.1.0-Alpha.17+mc1.21.5
		skycubed: SkyCubed 1.6.2
			me_owdding_patches_patches: patches 1.0.2
		skyhanni: SkyHanni 4.4.0
			libninepatch: LibNinePatch 1.2.0
		skyocean: SkyOcean 1.4.0
			skyblock-api: skyblock api 1.0.0-beta.140
			tech_thatgravyboat_repo-lib_repo-lib: repo-lib 2.0.2
		sodium: Sodium 0.6.13+mc1.21.5
		sounds: Sounds 2.4.12+1.21.5+fabric
			mixinextras: MixinExtras 0.5.0-rc.1
		spark: spark 1.10.138
		subtle_effects: Subtle Effects 1.11.0
		titanomachy: Titanomachy 1.0.0
			com_moulberry_mixinconstraints: mixinconstraints 1.0.8
		yet_another_config_lib_v3: YetAnotherConfigLib 3.7.1+1.21.5-fabric
			com_twelvemonkeys_common_common-image: common-image 3.12.0
			com_twelvemonkeys_common_common-io: common-io 3.12.0
			com_twelvemonkeys_common_common-lang: common-lang 3.12.0
			com_twelvemonkeys_imageio_imageio-core: imageio-core 3.12.0
			com_twelvemonkeys_imageio_imageio-metadata: imageio-metadata 3.12.0
			com_twelvemonkeys_imageio_imageio-webp: imageio-webp 3.12.0
			org_quiltmc_parsers_gson: gson 0.2.1
			org_quiltmc_parsers_json: json 0.2.1
		yosbr: YOSBR 0.1.2
		zoomify: Zoomify 2.14.2+1.21.3
			com_akuleshov7_ktoml-core-jvm: ktoml-core-jvm 0.5.2

</details>