### PR TITLE
Beacon Tuning Solver

### DIFF
--- a/src/main/java/nofrills/Main.java
+++ b/src/main/java/nofrills/Main.java
@@ -26,6 +26,7 @@ import nofrills.features.kuudra.*;
 import nofrills.features.mining.*;
 import nofrills.features.misc.*;
 import nofrills.features.slayer.*;
+import nofrills.features.solvers.BeaconTuningSolver;
 import nofrills.features.solvers.CalendarDate;
 import nofrills.features.solvers.ExperimentSolver;
 import nofrills.features.solvers.SpookyChests;
@@ -74,6 +75,7 @@ public class Main implements ModInitializer {
         eventBus.subscribe(HudManager.class);
         eventBus.subscribe(SpookyChests.class);
         eventBus.subscribe(ExperimentSolver.class);
+        eventBus.subscribe(BeaconTuningSolver.class);
         eventBus.subscribe(CalendarDate.class);
         eventBus.subscribe(VoidgloomSeraph.class);
         eventBus.subscribe(RiftstalkerBloodfiend.class);

--- a/src/main/java/nofrills/hud/clickgui/ClickGui.java
+++ b/src/main/java/nofrills/hud/clickgui/ClickGui.java
@@ -23,6 +23,7 @@ import nofrills.features.kuudra.*;
 import nofrills.features.mining.*;
 import nofrills.features.misc.*;
 import nofrills.features.slayer.*;
+import nofrills.features.solvers.BeaconTuningSolver;
 import nofrills.features.solvers.CalendarDate;
 import nofrills.features.solvers.ExperimentSolver;
 import nofrills.features.solvers.SpookyChests;
@@ -284,7 +285,8 @@ public class ClickGui extends BaseOwoScreen<FlowLayout> {
                         new Module("Calendar Date", CalendarDate.instance, "Calculates the exact starting dates of events in the calendar."),
                         new Module("Spooky Chests", SpookyChests.instance, "Highlights nearby trick or treat chests during the Spooky Festival.", new Settings(List.of(
                                 new Settings.ColorPicker("Color", true, SpookyChests.color, "The color of the spooky chest highlight.")
-                        )))
+                        ))),
+                        new Module("Beacon Tuning Solver", BeaconTuningSolver.instance, "Solves the beacon tuning mini-game on Galatea.")
                 )),
                 new Category("Fishing", List.of(
                         new Module("Cap Tracker", CapTracker.instance, "Tracks the sea creature cap. Mostly for barn fishing.", new Settings(List.of(

--- a/src/main/java/nofrills/misc/RenderColor.java
+++ b/src/main/java/nofrills/misc/RenderColor.java
@@ -5,6 +5,7 @@ import net.minecraft.util.math.ColorHelper;
 public class RenderColor {
     public static final RenderColor white = RenderColor.fromHex(0xffffff);
     public static final RenderColor green = RenderColor.fromHex(0x55ff55);
+    public static final RenderColor red = RenderColor.fromHex(0xff5555);
     public static final RenderColor darkGray = RenderColor.fromHex(0x202020);
 
     public float r;

--- a/src/main/java/nofrills/misc/Utils.java
+++ b/src/main/java/nofrills/misc/Utils.java
@@ -89,6 +89,18 @@ public class Utils {
         return ((TitleRendering) mc.inGameHud).nofrills_mod$isRenderingTitle();
     }
 
+    public static boolean isNearlyEqual(double a, double b, double eps) {
+        return Math.abs(a-b) < eps;
+    }
+
+    public static boolean isNearlyEqual(double a, double b) {
+        return isNearlyEqual(a, b, 1e-9);
+    }
+
+    public static boolean isNearlyEqual(float a, float b) {
+        return isNearlyEqual(a, b, 1e-5);
+    }
+
     public static void playSound(SoundEvent event, SoundCategory category, float volume, float pitch) {
         Vec3d coords = mc.cameraEntity.getPos();
         PositionedSoundInstance sound = new PositionedSoundInstance(event, category, volume, pitch, soundRandom, coords.getX(), coords.getY(), coords.getZ());

--- a/src/main/java/nofrills/mixin/HandledScreenMixin.java
+++ b/src/main/java/nofrills/mixin/HandledScreenMixin.java
@@ -21,6 +21,7 @@ import nofrills.features.general.NoRender;
 import nofrills.features.general.SlotBinding;
 import nofrills.features.kuudra.KuudraChestValue;
 import nofrills.features.misc.TooltipScale;
+import nofrills.features.solvers.BeaconTuningSolver;
 import nofrills.features.tweaks.MiddleClickFix;
 import nofrills.hud.LeapMenuButton;
 import nofrills.misc.*;
@@ -254,6 +255,17 @@ public abstract class HandledScreenMixin<T extends ScreenHandler> extends Screen
             context.getMatrices().translate(0, 0, 420);
             context.drawCenteredTextWithShadow(mc.textRenderer, value, baseX, baseY - 4, RenderColor.green.hex);
             context.fill((int) Math.floor(baseX - 2 - width * 0.5), baseY - 6, (int) Math.ceil(baseX + 2 + width * 0.5), baseY + 6, RenderColor.darkGray.argb);
+            context.getMatrices().pop();
+        }
+        if (BeaconTuningSolver.instance.isActive() && BeaconTuningSolver.colorSlot1Id != -1) {
+            Slot targetSlot = this.handler.getSlot(BeaconTuningSolver.colorSlot1Id);
+            int baseX = targetSlot.x - 9;
+            int baseY = targetSlot.y + 8;
+            context.getMatrices().push();
+            context.getMatrices().translate(0, 0, 420);
+            String value = Integer.toString(BeaconTuningSolver.colorTarget1);
+            RenderColor color = BeaconTuningSolver.colorTarget1 >= 0 ? RenderColor.green : RenderColor.red;
+            context.drawCenteredTextWithShadow(mc.textRenderer, value, baseX, baseY - 4, color.hex);
             context.getMatrices().pop();
         }
         for (Slot slot : this.handler.slots) {


### PR DESCRIPTION
Currently implemented only for the tune frequency minigame
the buttons lock themselves once in the right position, pitch check requires the pause to be held and to sound event to trigger once (still thinking about how to do it organically for the player), color has an extra helper to show closest click "path" to the target.

Will keep it as a draft, but comments/edits/suggestions appreciated.