### PR TITLE
Add optional injection point for RenderDoc

### DIFF
--- a/src/main/java/nofrills/Main.java
+++ b/src/main/java/nofrills/Main.java
@@ -59,6 +59,12 @@ public class Main implements ModInitializer {
 
         mc = MinecraftClient.getInstance();
 
+        String renderdocPath = System.getProperty("nofrills.renderdoc.library_path");
+        if (renderdocPath != null) {
+            System.load(renderdocPath);
+            LOGGER.info("Loaded RenderDoc lib: {}", renderdocPath);
+        }
+
         Config.load();
 
         ConfigScreenProviders.register(MOD_ID, screen -> new ClickGui());


### PR DESCRIPTION
Title. Should have zero overhead if argument is not specified (and technically not a problem if it is), would help with debugging of rendering features in dev. 