### PR TITLE
Move some events to run in render thread

### DIFF
--- a/src/main/java/nofrills/features/dungeons/TerracottaTimer.java
+++ b/src/main/java/nofrills/features/dungeons/TerracottaTimer.java
@@ -16,6 +16,7 @@ import nofrills.misc.Utils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Iterator;
 
 public class TerracottaTimer {
     public static final Feature instance = new Feature("terracottaTimer");
@@ -51,8 +52,7 @@ public class TerracottaTimer {
         if (instance.isActive() && Utils.isInDungeonBoss("6")) {
             if (event.newState.getBlock() instanceof FlowerPotBlock) { // EVERY POTTED FLOWER HAS ITS OWN BLOCK ID AAAAAAAAHHH
                 if (terracottas.stream().noneMatch(terra -> terra.pos.equals(event.pos))) {
-                    SpawningTerracotta terracotta = new SpawningTerracotta(event.pos, Utils.isOnDungeonFloor("M6") ? 240 : 300);
-                    terracottas.add(terracotta);
+                    terracottas.add(new SpawningTerracotta(event.pos, Utils.isOnDungeonFloor("M6") ? 240 : 300));
                 }
             }
             if (gyroTicks == 0 && event.oldState.isAir() && event.newState.getBlock().equals(Blocks.NETHER_BRICK_FENCE)) {
@@ -64,8 +64,8 @@ public class TerracottaTimer {
     @EventHandler
     private static void onRender(WorldRenderEvent event) {
         if (instance.isActive() && !terracottas.isEmpty() && Utils.isInDungeonBoss("6")) {
-            for (SpawningTerracotta terra : new ArrayList<>(terracottas)) {
-                if (terra == null || terra.pos == null) continue;
+            for (SpawningTerracotta terra : terracottas) {
+                if (terra.pos == null) continue;
                 MutableText text = Text.literal(Utils.formatDecimal(terra.ticks / 20.0f) + "s");
                 event.drawText(terra.pos.toCenterPos(), text, 0.035f, true, color.value());
             }
@@ -83,10 +83,14 @@ public class TerracottaTimer {
             if (gyroTicks > 0) {
                 gyroTicks--;
             }
-            for (SpawningTerracotta terra : new ArrayList<>(terracottas)) {
+
+            for (Iterator<SpawningTerracotta> it = terracottas.iterator(); it.hasNext();) {
+                SpawningTerracotta terra = it.next();
+
                 terra.tick();
+
                 if (terra.ticks == 0) {
-                    terracottas.remove(terra);
+                    it.remove();
                 }
             }
         }

--- a/src/main/java/nofrills/misc/SkyblockData.java
+++ b/src/main/java/nofrills/misc/SkyblockData.java
@@ -116,7 +116,7 @@ public class SkyblockData {
      * Returns a list with every line that is currently displayed on the scoreboard.
      */
     public static List<String> getLines() {
-        return new ArrayList<>(lines); // return a copy to avoid a potential concurrent modification exception
+        return lines;
     }
 
     public static void showPing() {

--- a/src/main/java/nofrills/mixin/ClientConnectionMixin.java
+++ b/src/main/java/nofrills/mixin/ClientConnectionMixin.java
@@ -20,19 +20,6 @@ import static nofrills.Main.eventBus;
 
 @Mixin(ClientConnection.class)
 public abstract class ClientConnectionMixin {
-    @Inject(method = "handlePacket", at = @At("HEAD"), cancellable = true)
-    private static void onPacketReceive(Packet<?> packet, PacketListener listener, CallbackInfo ci) {
-        if (packet instanceof CommonPingS2CPacket) {
-            eventBus.post(new ServerTickEvent());
-        }
-        if (packet instanceof PlayerListS2CPacket listPacket) {
-            SkyblockData.updateTabList(listPacket, listPacket.getEntries());
-        }
-        if (eventBus.post(new ReceivePacketEvent(packet)).isCancelled()) {
-            ci.cancel();
-        }
-    }
-
     @Inject(method = "send(Lnet/minecraft/network/packet/Packet;Lio/netty/channel/ChannelFutureListener;Z)V", at = @At("HEAD"), cancellable = true)
     private void onPacketSend(Packet<?> packet, @Nullable ChannelFutureListener channelFutureListener, boolean flush, CallbackInfo ci) {
         if (eventBus.post(new SendPacketEvent(packet)).isCancelled()) {

--- a/src/main/java/nofrills/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/nofrills/mixin/ClientPlayNetworkHandlerMixin.java
@@ -110,29 +110,4 @@ public class ClientPlayNetworkHandlerMixin {
     private void onScoreUpdate(TeamS2CPacket packet, CallbackInfo ci) {
         SkyblockData.updateScoreboard(packet);
     }
-
-    @Inject(method = "onGameJoin", at = @At("TAIL"))
-    private void onJoinGame(GameJoinS2CPacket packet, CallbackInfo ci) {
-        eventBus.post(new ServerJoinEvent());
-    }
-
-    @Inject(method = "onGameMessage", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/message/MessageHandler;onGameMessage(Lnet/minecraft/text/Text;Z)V"), cancellable = true)
-    private void onGameMessage(GameMessageS2CPacket packet, CallbackInfo ci) {
-        if (!packet.overlay()) {
-            String msg = Utils.toPlain(packet.content());
-            ChatMsgEvent event = eventBus.post(new ChatMsgEvent(packet.content(), msg));
-            if (event.isCancelled()) {
-                ci.cancel();
-            }
-            if (msg.startsWith("Party > ") && msg.contains(": ")) {
-                int nameStart = msg.contains("]") & msg.indexOf("]") < msg.indexOf(":") ? msg.indexOf("]") : msg.indexOf(">");
-                String[] clean = msg.replace(msg.substring(0, nameStart + 1), "").split(":", 2);
-                String author = clean[0].trim(), content = clean[1].trim();
-                boolean self = author.equalsIgnoreCase(mc.getSession().getUsername());
-                if (eventBus.post(new PartyChatMsgEvent(content, author, self)).isCancelled() && !ci.isCancelled()) {
-                    ci.cancel();
-                }
-            }
-        }
-    }
 }

--- a/src/main/java/nofrills/mixin/PacketApplyBatcherEntryMixin.java
+++ b/src/main/java/nofrills/mixin/PacketApplyBatcherEntryMixin.java
@@ -1,0 +1,46 @@
+package nofrills.mixin;
+
+import net.minecraft.network.listener.PacketListener;
+import net.minecraft.network.packet.Packet;
+import net.minecraft.network.packet.s2c.common.CommonPingS2CPacket;
+import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket;
+import nofrills.events.ReceivePacketEvent;
+import nofrills.events.SendPacketEvent;
+import nofrills.events.ServerTickEvent;
+import nofrills.misc.SkyblockData;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static nofrills.Main.eventBus;
+
+@Mixin(targets = "net.minecraft.network.PacketApplyBatcher$Entry")
+final class PacketApplyBatcherEntryMixin<T extends PacketListener> {
+    @Shadow
+    @NotNull
+    private Packet<T> packet;
+
+    private PacketApplyBatcherEntryMixin() {
+        super();
+
+        throw new UnsupportedOperationException("mixin class");
+    }
+
+    @Inject(method = "apply", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/packet/Packet;apply(Lnet/minecraft/network/listener/PacketListener;)V"), cancellable = true)
+    private final void nofrills$beforeMainThreadPacket(@NotNull final CallbackInfo ci) {
+        final var packet = this.packet;
+
+        if (packet instanceof CommonPingS2CPacket) {
+            eventBus.post(new ServerTickEvent());
+        } else if (packet instanceof PlayerListS2CPacket listPacket) {
+            SkyblockData.updateTabList(listPacket, listPacket.getEntries());
+        }
+
+        if (eventBus.post(new ReceivePacketEvent(packet)).isCancelled()) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/nofrills.mixins.json
+++ b/src/main/resources/nofrills.mixins.json
@@ -42,7 +42,8 @@
     "StatusEffectsDisplayMixin",
     "StuckObjectsFeatureRendererMixin",
     "WorldMixin",
-    "WorldRendererMixin"
+    "WorldRendererMixin",
+    "PacketApplyBatcherEntryMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This of course does not move all code to run in render thread. I'm sure theres more events that still do run in netty thread, but server tick event, join event, message event seems to be the most widely used ones and the ones used in terracotta timer.

Running logic in Netty thread is discouraged. It is meant for I/O. Any non-I/O work is a CPU-bound task (unless it blocks or calls rendering code, which would be horrible in netty thread) and so will delay packets even if a very small time. This also creates CMEs and all sorts of thread-safety issues. Minecraft itself dispatches all packet events to be handled in the render thread with the PacketApplyBatcher for this reason.

Fabric has standard events which always run in Render thread, made join and cancellable message receive events use Fabric standard events. This should increase both compatibility with other mods, and thread-safety. There is really no reason to use manual mixin injection points for things where Fabric has a native event for. The orbit event system can still be used together with Fabric events, by just registering to the fabric event then posting the orbit event from there.

For other stuff that depends on packets directly instead of game events, added a new mixin with a different injection point that runs in main thread at PacketApplyBatcher.

Removed now unnecessary list copying in SkyblockData#getLines and TerracottaTimer code, also reverting the local variable and null check which was a temporary fix for the issue.
 Iterator is used to avoid CME on single threaded code. Trying to remove entries while iterating is only supported with an explicit Iterator.

 The for-each syntax sugar also compiles down to an Iterator and this is trivial for JIT to optimize so the Iterator solution over for loop does not create any regressions.

 No snapshot list copy ensures thread-safety bugs fail-fast with a CME in the future.

 for loop with 2 components (assignment and condition) is used instead of it = terracottas.iterator(); and while (it.hasNext()) as it makes the iterator local variable's scope limited to inside the loop.

I have not checked if any more places that do unnecessary list copying can be optimized after the changes, SkyblockData and TerracottaTimer was the only places I looked. More in-depth refactor might be needed later.

PacketApplyBatcherEntryMixin does not apply cleanly to 1.21.8. Only to 1.21.10 and 1.21.11. In 1.21.8, the class that does the batching seems to be NetworkThreadUtils in case anyone else wants to backport to 1.21.8.

Everything works per initial testing of me, but more testing is definitely needed. Will mark it as a draft PR. Feel free to close it if you are going to do cleanup yourself (e.g., to use fabric events instead of mixins) - otherwise I'll test more and eventually unmark from draft if i get no crashes or bugs related to the changes.