### PR TITLE
Better config saving

### DIFF
--- a/src/main/java/nofrills/config/Config.java
+++ b/src/main/java/nofrills/config/Config.java
@@ -1,5 +1,7 @@
 package nofrills.config;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import net.fabricmc.loader.api.FabricLoader;
@@ -15,6 +17,7 @@ public class Config {
     private static final Path folderPath = FabricLoader.getInstance().getConfigDir().resolve("NoFrills");
     private static final Path filePath = folderPath.resolve("Configuration.json");
     private static final Path tempPath = folderPath.resolve("Temp.json");
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     private static JsonObject data = new JsonObject();
     private static int hash = 0;
 
@@ -36,7 +39,7 @@ public class Config {
             if (!Files.exists(folderPath)) {
                 Files.createDirectory(folderPath);
             }
-            Files.writeString(tempPath, data.toString());
+            Files.writeString(tempPath, GSON.toJson(data));
             try {
                 Files.move(tempPath, filePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
             } catch (AtomicMoveNotSupportedException ignored) {
@@ -49,7 +52,7 @@ public class Config {
     }
 
     public static void saveAsync() {
-        new Thread(Config::save).start();
+        Thread.startVirtualThread(Config::save);
     }
 
     public static int getHash() {


### PR DESCRIPTION
- Save prettified json instead of minimized json. The toString() is mainly used when logging or debugging. Gson#toJson is the correct way to pretty print JSON with indentation and line breaks. This allows external reading of config file non-programmatically is easier for the eye, and users can paste config when for example creating a new issue as a reference easier. The extra space used in disk for the json file is largely irrelevant, and the space consumed in RAM is same as the prettified string is not stored, discarded after saving.

- Use Virtual Thread to save the config. Creating a new short-lived (platform) thread per task is largely wasteful. For years, Executors class provided us fixed, cached, scheduled thread pools - now we have even better, Virtual Threads can allow creating a thread per task with no significiant extra overhead. Virtual Threads are available as a stable feature since Java 21 LTS, defined by JEP 444.

Small enough changes, was just using them myself locally and wanted to upstream. Feel free to close if it's not worth merging