### PR TITLE
Use pretty-printed JSON for config save again

### DIFF
--- a/src/main/java/nofrills/config/Config.java
+++ b/src/main/java/nofrills/config/Config.java
@@ -41,18 +41,7 @@ public class Config {
 
     public static void save() {
         try {
-            var pretty = GSON.toJson(data);
-            if (!Files.exists(folderPath)) {
-                Files.createDirectory(folderPath);
-            }
-            Files.writeString(tempPath, pretty);
-            try {
-                Files.move(tempPath, filePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-            } catch (AtomicMoveNotSupportedException ignored) {
-                Files.move(tempPath, filePath, StandardCopyOption.REPLACE_EXISTING);
-            }
-            Files.deleteIfExists(tempPath);
-            Utils.atomicWrite(filePath, pretty);
+            Utils.atomicWrite(filePath, GSON.toJson(data));
         } catch (Exception exception) {
             LOGGER.error("Unable to save NoFrills config file!", exception);
         }


### PR DESCRIPTION
Broken after introduction of atomic save system. Files.writeString used GSON.toJson (pretty), while Utils.atomicWrite code further below used data.toString() directly.

This resulted in the config file reverting back to a one-line JSON file, which is unreadable externally and is not helpful when you have a .git repository on your .minecraft/config directory:

<img width="1473" height="614" alt="image" src="https://github.com/user-attachments/assets/4505875b-1411-41df-8c2f-f1add6e14b65" />

(Use case for a .git repository in config folder is to keep track of what I enable and disable so I can disable stuff if there's any regressions. Occassionally I commit known good stable configs, and update my mods afterwards. A nice backup in case configs ever corrupt as well. Helps me manage some of the mods that default to enabled for new features as well, where I disable each default enableds if i don't need, NoFrills does correct by defaulting to false but some other mods I don't want to name does not.)

I've introduced a new local variable with name pretty to avoid confusion in the future. The local variable should be used instead of repeated GSON.toJson or incorrect data.toString() calls as the text representation of the config, but we could most probably also override Object#toString for Config, and then when saving do this.toString() instead of data.toString() or GSON.toJson, I've decided to keep this PR simple though, feel free to do that later.