### PR TITLE
fix(TerracottaTimer): don't show second gyro timer on F6

### DIFF
--- a/src/main/java/nofrills/features/dungeons/TerracottaTimer.java
+++ b/src/main/java/nofrills/features/dungeons/TerracottaTimer.java
@@ -55,7 +55,7 @@ public class TerracottaTimer {
                     terracottas.add(terracotta);
                 }
             }
-            if (gyroTicks == 0 && event.oldState.isAir() && event.newState.getBlock().equals(Blocks.NETHER_BRICK_FENCE)) {
+            if (Utils.isOnDungeonFloor("M6") && gyroTicks == 0 && event.oldState.isAir() && event.newState.getBlock().equals(Blocks.NETHER_BRICK_FENCE)) {
                 gyroTicks = 235;
             }
         }


### PR DESCRIPTION
On F6, Terracottas only respawn once, so the second gyro timer appers to be just counting down to nothing.