### PR TITLE
fix: don't highlight Spirit Bear spawned by Watcher

### DIFF
--- a/src/main/java/nofrills/features/dungeons/MinibossHighlight.java
+++ b/src/main/java/nofrills/features/dungeons/MinibossHighlight.java
@@ -32,9 +32,13 @@ public class MinibossHighlight {
     @EventHandler
     private static void onUpdated(EntityUpdatedEvent event) {
         if (instance.isActive() && Utils.isInDungeons() && event.entity instanceof PlayerEntity player && !Utils.isPlayer(player)) {
-            if (minibossList.contains(player.getName().getString()) && !cache.has(event.entity)) {
+            String name = player.getName().getString();
+            if (minibossList.contains(name) && !cache.has(event.entity)) {
                 if (Utils.isInDungeonBoss("4") && event.entity.getEntityPos().getY() >= 76.0) {
                     return; // prevents the Floor 4 "crowd" NPC's from getting highlighted
+                }
+                if (!Utils.isInDungeonBoss("4") && name.equals("Spirit Bear")) {
+                    return; // prevents the Spirit Bear spawned by the Watcher from getting highlighted
                 }
                 cache.add(event.entity);
             }


### PR DESCRIPTION
I see no reason to highlight this one in particular, considering the other Watcher minis aren't highlighted by Miniboss Highlight.