### PR TITLE
Feature: Add Builder's Ruler preview with HUD counter

### DIFF
--- a/src/main/java/nofrills/Main.java
+++ b/src/main/java/nofrills/Main.java
@@ -148,6 +148,9 @@ public class Main implements ModInitializer {
         eventBus.subscribe(PartyCommands.class);
         eventBus.subscribe(NoRender.class);
         eventBus.subscribe(EtherwarpOverlay.class);
+        eventBus.subscribe(EtherwarpOverlay.class);
+        eventBus.subscribe(BuilderRulerPreview.class);
+        eventBus.subscribe(ChatWaypoints.class);
         eventBus.subscribe(ChatWaypoints.class);
         eventBus.subscribe(AutoSprint.class);
         eventBus.subscribe(RareHighlight.class);

--- a/src/main/java/nofrills/features/general/BuilderRulerPreview.java
+++ b/src/main/java/nofrills/features/general/BuilderRulerPreview.java
@@ -1,0 +1,112 @@
+package nofrills.features.general;
+
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.block.BlockState;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.Direction;
+import nofrills.config.Feature;
+import nofrills.config.SettingColor;
+import nofrills.config.SettingEnum;
+import nofrills.events.WorldRenderEvent;
+import nofrills.events.WorldTickEvent;
+import nofrills.hud.elements.BuilderRulerCounter;
+import nofrills.misc.RenderColor;
+import nofrills.misc.RenderStyle;
+import nofrills.misc.Utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static nofrills.Main.mc;
+
+public class BuilderRulerPreview {
+    public static final Feature instance = new Feature("builderRulerPreview");
+
+    public static final SettingEnum<RenderStyle> highlightStyle = new SettingEnum<>(RenderStyle.Outline, RenderStyle.class, "highlightStyle", instance.key());
+    public static final SettingColor placeColor = new SettingColor(new RenderColor(0, 200, 255, 160), "placeColor", instance.key());
+    public static final SettingColor destroyColor = new SettingColor(new RenderColor(255, 80, 80, 160), "destroyColor", instance.key());
+    public static final SettingColor outlinePlaceColor = new SettingColor(new RenderColor(0, 200, 255, 255), "outlinePlaceColor", instance.key());
+    public static final SettingColor outlineDestroyColor = new SettingColor(new RenderColor(255, 80, 80, 255), "outlineDestroyColor", instance.key());
+
+    private static final int MAX_RANGE = 241;
+
+    private static final int PLOT_SIZE = 96;
+    private static final int PLOT_OFFSET = 48;
+
+    private static final List<BlockPos> cachedBlocks = new java.util.concurrent.CopyOnWriteArrayList<>();
+    private static boolean cachedPlace = true;
+
+    @EventHandler
+    private static void onTick(WorldTickEvent event) {
+        cachedBlocks.clear();
+        if (!instance.isActive() || mc.player == null || mc.world == null) return;
+
+        String id = Utils.getSkyblockId(Utils.getCustomData(Utils.getHeldItem()));
+        if (id == null || !id.equals("BUILDERS_RULER")) {
+            if (BuilderRulerCounter.instance != null) BuilderRulerCounter.instance.hide();
+            return;
+        }
+
+        cachedPlace = !mc.options.sneakKey.isPressed();
+
+        HitResult hit = mc.player.raycast(5.0, 0f, false);
+        if (hit.getType() != HitResult.Type.BLOCK) return;
+
+        BlockHitResult blockHit = (BlockHitResult) hit;
+        BlockPos target = blockHit.getBlockPos();
+        Direction face = blockHit.getSide();
+        Direction moveDir = mc.player.getHorizontalFacing();
+
+        if (cachedPlace) {
+            BlockPos startPos = target.offset(face);
+            BlockPos cursor = startPos;
+            for (int i = 0; i < MAX_RANGE; i++) {
+                if (!mc.world.getBlockState(cursor).isAir()) break;
+                if (!isInPlot(startPos, cursor)) break;
+                cachedBlocks.add(cursor);
+                cursor = cursor.offset(moveDir);
+            }
+        } else {
+            net.minecraft.block.Block startBlock = mc.world.getBlockState(target).getBlock();
+            BlockPos cursor = target;
+            for (int i = 0; i < MAX_RANGE; i++) {
+                BlockState state = mc.world.getBlockState(cursor);
+                if (state.getBlock() != startBlock) break;
+                if (!isInPlot(target, cursor)) break;
+                cachedBlocks.add(cursor);
+                cursor = cursor.offset(moveDir);
+            }
+        }
+
+        if (BuilderRulerCounter.instance != null) {
+            BuilderRulerCounter.instance.update(cachedBlocks.size(), cachedBlocks.size(), cachedPlace);
+        }
+    }
+
+    @EventHandler
+    public static void onRender(WorldRenderEvent event) {
+        if (!instance.isActive() || mc.player == null || mc.world == null || cachedBlocks.isEmpty()) return;
+
+        String id = Utils.getSkyblockId(Utils.getCustomData(Utils.getHeldItem()));
+        if (id == null || !id.equals("BUILDERS_RULER")) return;
+
+        RenderColor fill = cachedPlace ? placeColor.value() : destroyColor.value();
+        RenderColor outline = cachedPlace ? outlinePlaceColor.value() : outlineDestroyColor.value();
+
+        for (BlockPos pos : cachedBlocks) {
+            event.drawStyled(new Box(pos), highlightStyle.value(), true, outline, fill);
+        }
+    }
+
+    private static boolean isInPlot(BlockPos startPos, BlockPos pos) {
+        if (!Utils.isInGarden()) {
+            return true;
+        }
+
+        return Math.floorDiv(startPos.getX() + PLOT_OFFSET, PLOT_SIZE) == Math.floorDiv(pos.getX() + PLOT_OFFSET, PLOT_SIZE)
+                && Math.floorDiv(startPos.getZ() + PLOT_OFFSET, PLOT_SIZE) == Math.floorDiv(pos.getZ() + PLOT_OFFSET, PLOT_SIZE);
+    }
+}

--- a/src/main/java/nofrills/hud/HudManager.java
+++ b/src/main/java/nofrills/hud/HudManager.java
@@ -42,6 +42,7 @@ public class HudManager {
     public static final FishingBobber bobber = new FishingBobber("Bobber: §7Inactive");
     public static final ShardTrackerDisplay shardTracker = new ShardTrackerDisplay();
     public static final SkillTrackerDisplay skillTracker = new SkillTrackerDisplay();
+    public static final BuilderRulerCounter builderRulerCounter = new BuilderRulerCounter("Place: §f0 §7/ §f0");
 
     public static boolean isEditingHud() {
         return mc.currentScreen instanceof HudEditorScreen;

--- a/src/main/java/nofrills/hud/clickgui/ClickGui.java
+++ b/src/main/java/nofrills/hud/clickgui/ClickGui.java
@@ -134,6 +134,13 @@ public class ClickGui extends BaseOwoScreen<FlowLayout> {
                                 new Settings.SliderInt("Duration", 1, 600, 1, ChatWaypoints.allDuration, "The duration (in seconds) that all chat waypoints should be rendered for."),
                                 new Settings.ColorPicker("Color", ChatWaypoints.allColor, "The color used for the all chat waypoints.")
                         ))),
+                        new Module("Builder Ruler Preview", BuilderRulerPreview.instance, "Highlights blocks that will be placed or destroyed by the Builder's Ruler.", new Settings(List.of(
+                                new Settings.Dropdown<>("Highlight Style", BuilderRulerPreview.highlightStyle, "The style of the highlight."),
+                                new Settings.ColorPicker("Place Fill", BuilderRulerPreview.placeColor, "Fill color for placement preview."),
+                                new Settings.ColorPicker("Place Outline", BuilderRulerPreview.outlinePlaceColor, "Outline color for placement preview."),
+                                new Settings.ColorPicker("Destroy Fill", BuilderRulerPreview.destroyColor, "Fill color for destroy preview."),
+                                new Settings.ColorPicker("Destroy Outline", BuilderRulerPreview.outlineDestroyColor, "Outline color for destroy preview.")
+                        ))),
                         new Module("Etherwarp Overlay", EtherwarpOverlay.instance, "Highlights the block you are targeting with the Ether Transmission ability.", new Settings(List.of(
                                 new Settings.Separator("Sound"),
                                 new Settings.Toggle("Warp Sound", EtherwarpOverlay.doSound, "Plays a custom sound effect upon teleporting."),

--- a/src/main/java/nofrills/hud/elements/BuilderRulerCounter.java
+++ b/src/main/java/nofrills/hud/elements/BuilderRulerCounter.java
@@ -1,0 +1,34 @@
+package nofrills.hud.elements;
+
+import io.wispforest.owo.ui.core.OwoUIGraphics;
+import net.minecraft.text.Text;
+import nofrills.config.Feature;
+import nofrills.hud.SimpleTextElement;
+import nofrills.misc.Utils;
+
+public class BuilderRulerCounter extends SimpleTextElement {
+
+    public static BuilderRulerCounter instance;
+
+    public BuilderRulerCounter(String text) {
+        super(Text.literal(text), new Feature("builderRulerCounter"), "Builder Ruler Counter");
+        this.setDesc("Shows how many blocks will be placed or removed by the Builder's Ruler.");
+        instance = this;
+    }
+
+    @Override
+    public void draw(OwoUIGraphics context, int mouseX, int mouseY, float partialTicks, float delta) {
+        if (this.shouldRender()) {
+            super.draw(context, mouseX, mouseY, partialTicks, delta);
+        }
+    }
+
+    public void update(int count, int max, boolean place) {
+        String action = place ? "§aPlace" : "§cRemove";
+        this.setText(Utils.format("{}: §f{} §7/ §f{}", action, count, max));
+    }
+
+    public void hide() {
+        this.setText("");
+    }
+}


### PR DESCRIPTION
# What 
Adds a visual block highlight preview for the Builder's Ruler item in Hypixel SkyBlock.

# Features
- Highlights blocks that will be **placed** (blue) or **destroyed** (red) in a line
- Integrates with `BuilderRulerCounter` HUD element to show block count
- Respects **plot boundaries** — preview stops at plot edge (Garden only) 
- Outside Garden, line extends freely up to 241 blocks 

# Settings
- `highlightStyle` — Outline / Fill / Both
- `placeColor` / `destroyColor` — fill colors
- `outlinePlaceColor` / `outlineDestroyColor` — outline colors

## Preview
<details>
<summary>Images</summary>

<img width="1366" height="705" alt="1st" src="https://github.com/user-attachments/assets/f09cc7dc-8581-4d43-87b4-2943c09d6205" />
<img width="1366" height="705" alt="2nd" src="https://github.com/user-attachments/assets/b14a61c6-3fa0-4f10-ba06-aeaca200119e" />

</details>