### PR TITLE
fix(MiddleClickOverride): add Composter and Midas Anvil to blacklist

### DIFF
--- a/src/main/java/nofrills/features/tweaks/MiddleClickOverride.java
+++ b/src/main/java/nofrills/features/tweaks/MiddleClickOverride.java
@@ -42,7 +42,9 @@ public class MiddleClickOverride {
             "Pet Sitter",
             "Transfer to Profile",
             "Attribute Transfer",
-            "Hunting Box"
+            "Hunting Box",
+            "Composter",
+            "Midas Anvil",
     );
     private static final HashSet<String> matchWhitelist = Sets.newHashSet(
             "Your Equipment and Stats",

--- a/src/main/java/nofrills/features/tweaks/MiddleClickOverride.java
+++ b/src/main/java/nofrills/features/tweaks/MiddleClickOverride.java
@@ -44,7 +44,7 @@ public class MiddleClickOverride {
             "Attribute Transfer",
             "Hunting Box",
             "Composter",
-            "Midas Anvil",
+            "Midas Anvil"
     );
     private static final HashSet<String> matchWhitelist = Sets.newHashSet(
             "Your Equipment and Stats",


### PR DESCRIPTION
* Composter: Can't click Insert Crops from Sacks/Insert Fuel from Sacks
* Midas Anvil: Can't click the anvil