### PR TITLE
ci: upload artifact without zipping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,10 @@ jobs:
       - name: build
         run: ./gradlew build
       - name: capture build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
-          name: Artifacts
-          path: build/libs/
+          path: build/libs/*
+          archive: false
       - name: post beta
         if: ${{ success() }}
         run: |


### PR DESCRIPTION
Changes the workflow to upload build artifacts without an additional layer of zipping, per <https://github.blog/changelog/2026-02-26-github-actions-now-supports-uploading-and-downloading-non-zipped-artifacts/>.