### PR TITLE
feat(Utils): use more reliable method for isPlayer

### DIFF
--- a/src/main/java/nofrills/misc/Utils.java
+++ b/src/main/java/nofrills/misc/Utils.java
@@ -298,21 +298,10 @@ public class Utils {
     }
 
     /**
-     * Checks if a PlayerEntity is a real player, and not an enemy or NPC. Some NPCs might falsely return true for a few seconds after spawning.
+     * Checks if a PlayerEntity is a real player, and not an enemy or NPC.
      */
     public static boolean isPlayer(PlayerEntity entity) {
-        ClientPlayNetworkHandler handler = mc.getNetworkHandler();
-        if (handler != null) {
-            PlayerListEntry listEntry = handler.getPlayerListEntry(entity.getUuid());
-            if (listEntry != null) {
-                String displayName = listEntry.getProfile().name();
-                if (displayName != null) {
-                    String name = Formatting.strip(displayName);
-                    return !name.isEmpty() && !name.contains(" ");
-                }
-            }
-        }
-        return entity == mc.player;
+        return entity.getUuid().version() == 4;
     }
 
     /**


### PR DESCRIPTION
NPCs always have a UUID that's not version 4, so this is a simpler and more reliable check. This is essentially the officially recommended method as well: https://hypixel.net/threads/preventing-stat-requests-for-npcs-dynamic-nametag-positioning.6002938/#post-41316731