### PR TITLE
0.26.1 enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ It's in the name. Simple and effective Hypixel Skyblock mod for modern versions 
     - **Instant Sneak**: Removes the smooth sneaking/swimming animation.
     - **Eye Height Fix**: Visually reverts the sneaking eye height on islands without modern version support.
     - **No Ghost Place**: Prevents ghost blocks from appearing when placing non-placeable Skyblock block items.
+    - **Mute Explosion**: Prevents the explosion sound from playing (useful for Explosive Arrow).
 
 - **Misc**
 

--- a/src/main/java/nofrills/features/tweaks/MiddleClickOverride.java
+++ b/src/main/java/nofrills/features/tweaks/MiddleClickOverride.java
@@ -47,7 +47,7 @@ public class MiddleClickOverride {
             "Midas Anvil"
     );
     private static final HashSet<String> matchWhitelist = Sets.newHashSet(
-            "Your Equipment and Stats",
+            "Stats & Equipment",
             "Accessory Bag Thaumaturgy",
             "Community Shop"
     );

--- a/src/main/java/nofrills/features/tweaks/MuteExplosion.java
+++ b/src/main/java/nofrills/features/tweaks/MuteExplosion.java
@@ -1,0 +1,21 @@
+package nofrills.features.tweaks;
+
+import meteordevelopment.orbit.EventHandler;
+import net.minecraft.sounds.SoundEvents;
+import nofrills.config.Feature;
+import nofrills.config.SettingBool;
+import nofrills.events.EventListener;
+import nofrills.events.PlaySoundEvent;
+import nofrills.misc.Utils;
+
+@EventListener
+public class MuteExplosion {
+    public static final Feature instance = new Feature("muteExplosion");
+    public static final SettingBool dungeonsOnly = new SettingBool(false, "dungeonsOnly", instance.key());
+
+    @EventHandler
+    private static void onSound(PlaySoundEvent event) {
+        if (instance.isActive() && event.isSound(SoundEvents.GENERIC_EXPLODE) && (!dungeonsOnly.value() || Utils.isInDungeons()))
+            event.cancel();
+    }
+}

--- a/src/main/java/nofrills/hud/clickgui/ClickGui.java
+++ b/src/main/java/nofrills/hud/clickgui/ClickGui.java
@@ -301,6 +301,9 @@ public class ClickGui extends BaseOwoScreen<FlowLayout> {
                                 new Settings.Toggle("No Tooltip Styling", LegacyTextures.noTooltipStyle, "Disables custom styling of tooltips. Reverts item tooltips if the official pack is below the vanilla pack."),
                                 new Settings.Toggle("No Bow Cooldown", LegacyTextures.noBowCooldown, "Prevents the cooldown overlay from rendering on bows/shortbows."),
                                 new Settings.Toggle("More Legacy", LegacyTextures.moreLegacy, "Reverts several items which used to be axes (before the Foraging Update) into axes.")
+                        )),
+                        new Module("Mute Explosion", MuteExplosion.instance, "Prevents the explosion sound from playing.", new Settings(
+                                new Settings.Toggle("Dungeons Only", MuteExplosion.dungeonsOnly, "Only mute the explosion sound while in Dungeons.")
                         ))
                 )),
                 new Category("Misc", List.of(


### PR DESCRIPTION
According to the patch notes:
> Renamed the "Your SkyBlock Profile" button in the SkyBlock Menu to "Stats & Equipment*

> Explosive Arrows no longer damage yourself.